### PR TITLE
Rewrite Hash#value_counts in C

### DIFF
--- a/lib/enumerable/statistics.rb
+++ b/lib/enumerable/statistics.rb
@@ -7,4 +7,3 @@ module Enumerable
 end
 
 require_relative 'statistics/enumerable_ext'
-require_relative 'statistics/hash_ext'

--- a/lib/enumerable/statistics/hash_ext.rb
+++ b/lib/enumerable/statistics/hash_ext.rb
@@ -1,1 +1,0 @@
-require_relative 'hash_ext/value_counts'

--- a/lib/enumerable/statistics/hash_ext/value_counts.rb
+++ b/lib/enumerable/statistics/hash_ext/value_counts.rb
@@ -1,5 +1,0 @@
-class Hash
-  def value_counts(*args, **kwargs)
-    each_value.value_counts(*args, **kwargs)
-  end
-end


### PR DESCRIPTION
This acheives 1.7x-3.0x faster computation.

```
$ be benchmark-driver bench/hash_value_counts.yml
Warming up --------------------------------------
              inject   251.277k i/s -    273.156k times in 1.087070s (3.98μs/i)
       unsort_keepna   128.549k i/s -    132.572k times in 1.031298s (7.78μs/i)
       unsort_dropna   130.421k i/s -    132.462k times in 1.015646s (7.67μs/i)
         sort_keepna    98.975k i/s -    104.962k times in 1.060491s (10.10μs/i)
         sort_dropna   102.865k i/s -    104.533k times in 1.016219s (9.72μs/i)
  norm_unsort_keepna   104.047k i/s -    106.865k times in 1.027085s (9.61μs/i)
  norm_unsort_dropna   107.039k i/s -    112.618k times in 1.052121s (9.34μs/i)
    norm_sort_keepna    81.159k i/s -     84.799k times in 1.044845s (12.32μs/i)
    norm_sort_dropna    82.339k i/s -     86.064k times in 1.045237s (12.14μs/i)
     sort_asc_keepna    99.943k i/s -    105.710k times in 1.057700s (10.01μs/i)
     sort_asc_dropna   101.425k i/s -    103.829k times in 1.023700s (9.86μs/i)
norm_sort_asc_keepna    78.735k i/s -     80.498k times in 1.022389s (12.70μs/i)
norm_sort_asc_dropna    81.152k i/s -     87.120k times in 1.073539s (12.32μs/i)
Calculating -------------------------------------
                      1.1.0.dev        HEAD
              inject   257.322k    258.558k i/s -    753.831k times in 2.929526s 2.915516s
       unsort_keepna   127.457k    348.297k i/s -    385.646k times in 3.025693s 1.107233s
       unsort_dropna   131.658k    358.053k i/s -    391.264k times in 2.971824s 1.092755s
         sort_keepna   100.566k    166.451k i/s -    296.924k times in 2.952525s 1.783850s
         sort_dropna   103.643k    173.806k i/s -    308.593k times in 2.977448s 1.775501s
  norm_unsort_keepna   105.317k    295.755k i/s -    312.140k times in 2.963824s 1.055400s
  norm_unsort_dropna   106.623k    314.769k i/s -    321.117k times in 3.011699s 1.020168s
    norm_sort_keepna    79.804k    148.825k i/s -    243.478k times in 3.050963s 1.636001s
    norm_sort_dropna    82.455k    150.668k i/s -    247.017k times in 2.995780s 1.639479s
     sort_asc_keepna   100.356k    168.335k i/s -    299.829k times in 2.987664s 1.781142s
     sort_asc_dropna   101.414k    171.604k i/s -    304.275k times in 3.000334s 1.773118s
norm_sort_asc_keepna    79.951k    156.521k i/s -    236.205k times in 2.954385s 1.509093s
norm_sort_asc_dropna    81.341k    158.202k i/s -    243.456k times in 2.993027s 1.538894s

Comparison:
                           inject
                HEAD:    258558.3 i/s
           1.1.0.dev:    257321.8 i/s - 1.00x  slower

                    unsort_keepna
                HEAD:    348297.1 i/s
           1.1.0.dev:    127457.1 i/s - 2.73x  slower

                    unsort_dropna
                HEAD:    358052.8 i/s
           1.1.0.dev:    131657.9 i/s - 2.72x  slower

                      sort_keepna
                HEAD:    166451.2 i/s
           1.1.0.dev:    100566.1 i/s - 1.66x  slower

                      sort_dropna
                HEAD:    173806.2 i/s
           1.1.0.dev:    103643.5 i/s - 1.68x  slower

               norm_unsort_keepna
                HEAD:    295755.2 i/s
           1.1.0.dev:    105316.6 i/s - 2.81x  slower

               norm_unsort_dropna
                HEAD:    314768.7 i/s
           1.1.0.dev:    106623.2 i/s - 2.95x  slower

                 norm_sort_keepna
                HEAD:    148825.1 i/s
           1.1.0.dev:     79803.7 i/s - 1.86x  slower

                 norm_sort_dropna
                HEAD:    150668.0 i/s
           1.1.0.dev:     82455.0 i/s - 1.83x  slower

                  sort_asc_keepna
                HEAD:    168335.3 i/s
           1.1.0.dev:    100355.7 i/s - 1.68x  slower

                  sort_asc_dropna
                HEAD:    171604.5 i/s
           1.1.0.dev:    101413.7 i/s - 1.69x  slower

             norm_sort_asc_keepna
                HEAD:    156521.2 i/s
           1.1.0.dev:     79950.6 i/s - 1.96x  slower

             norm_sort_asc_dropna
                HEAD:    158201.9 i/s
           1.1.0.dev:     81341.1 i/s - 1.94x  slower
```