### PR TITLE
Proof of concept - Shared Edge histogram

### DIFF
--- a/ext/enumerable/statistics/extension/statistics.c
+++ b/ext/enumerable/statistics/extension/statistics.c
@@ -2333,7 +2333,6 @@ ary_dual_histograms(int argc, VALUE *argv, VALUE ary)
 
   VALUE ary_edge, compare_ary_edge;
   VALUE ary_nbins, compare_ary_nbins;
-  long nbins, nweights, i;
   VALUE compare_ary;
 
   rb_scan_args(argc, argv, "01:", &arg0, &opts);
@@ -2349,13 +2348,16 @@ ary_dual_histograms(int argc, VALUE *argv, VALUE ary)
   VALUE all_edges, edges_max, edges_min;
   all_edges = rb_ary_plus(ary_edge, compare_ary_edge);
 
-  VALUE ary_diff, compare_ary_diff, diff;
-  VALUE average_diff;
+  VALUE ary_diff, compare_ary_diff, average_diff;
 
   ary_diff = rb_funcall(rb_ary_entry(ary_edge, 1), idMINUS, 1, rb_ary_entry(ary_edge, 0));
   compare_ary_diff = rb_funcall(rb_ary_entry(compare_ary_edge, 1), idMINUS, 1, rb_ary_entry(compare_ary_edge, 0));
   /* average_diff = rb_funcall(rb_funcall(ary_diff, idPLUS, 1, compare_ary_diff), rb_intern("/"), 1, rb_intern("2")); */
   average_diff = rb_funcall(rb_funcall(ary_diff, idPLUS, 1, compare_ary_diff), idDIV, 1, DBL2NUM(2.0));
+
+  edges_max = rb_funcall(all_edges, rb_intern("max"), 0);
+  edges_min = rb_funcall(all_edges, rb_intern("min"), 0);
+  rb_p(edges_min);
 
   rb_p(average_diff);
 

--- a/ext/enumerable/statistics/extension/statistics.c
+++ b/ext/enumerable/statistics/extension/statistics.c
@@ -2343,10 +2343,23 @@ ary_dual_histograms(int argc, VALUE *argv, VALUE ary)
   ary_nbins = sturges(RARRAY_LEN(ary));
   ary_edge = ary_histogram_calculate_edge(ary, ary_nbins, left_p);
 
-  /* compare_ary_nbins = sturges(RARRAY_LEN(ary)); */
-  /* compare_edge = ary_histogram_calculate_edge(compare_ary, compare_ary_nbins, left_p); */
+  compare_ary_nbins = sturges(RARRAY_LEN(ary));
+  compare_ary_edge = ary_histogram_calculate_edge(compare_ary, compare_ary_nbins, left_p);
 
-  return ary_edge;
+  VALUE all_edges, edges_max, edges_min;
+  all_edges = rb_ary_plus(ary_edge, compare_ary_edge);
+
+  VALUE ary_diff, compare_ary_diff, diff;
+  VALUE average_diff;
+
+  ary_diff = rb_funcall(rb_ary_entry(ary_edge, 1), idMINUS, 1, rb_ary_entry(ary_edge, 0));
+  compare_ary_diff = rb_funcall(rb_ary_entry(compare_ary_edge, 1), idMINUS, 1, rb_ary_entry(compare_ary_edge, 0));
+  /* average_diff = rb_funcall(rb_funcall(ary_diff, idPLUS, 1, compare_ary_diff), rb_intern("/"), 1, rb_intern("2")); */
+  average_diff = rb_funcall(rb_funcall(ary_diff, idPLUS, 1, compare_ary_diff), idDIV, 1, DBL2NUM(2.0));
+
+  rb_p(average_diff);
+
+  return compare_ary_edge;
 }
 
 

--- a/ext/enumerable/statistics/extension/statistics.c
+++ b/ext/enumerable/statistics/extension/statistics.c
@@ -95,7 +95,7 @@ static VALUE half_in_rational;
 
 static ID idPow, idPLUS, idMINUS, idSTAR, idDIV, idGE;
 static ID id_eqeq_p, id_idiv, id_negate, id_to_f, id_cmp, id_nan_p;
-static ID id_each, id_real_p, id_sum, id_population, id_closed, id_edge;
+static ID id_each, id_real_p, id_sum, id_population, id_closed, id_compare, id_edge;
 
 static VALUE sym_left, sym_right;
 
@@ -2148,6 +2148,22 @@ opt_closed_left_p(VALUE opts)
   return left_p;
 }
 
+static VALUE
+opt_compare_array(VALUE opts)
+{
+
+  if (!NIL_P(opts)) {
+    VALUE compare;
+#ifdef HAVE_RB_GET_KWARGS
+    ID kwargs = id_compare;
+    rb_get_kwargs(opts, &kwargs, 0, 1, &compare);
+#else
+    compare = rb_hash_lookup2(opts, ID2SYM(id_compare), sym_left);
+#endif
+  return compare;
+  }
+}
+
 static inline long
 sturges(long n)
 {
@@ -2309,6 +2325,20 @@ ary_histogram(int argc, VALUE *argv, VALUE ary)
                        left_p ? sym_left : sym_right,
                        Qfalse);
 }
+static VALUE
+ary_dual_histograms(int argc, VALUE *argv, VALUE ary)
+{
+  VALUE arg0, opts;
+  int left_p;
+  long nbins, nweights, i;
+  VALUE compare;
+
+  rb_scan_args(argc, argv, "01:", &arg0, &opts);
+  compare = opt_compare_array(opts);
+
+  return compare;
+}
+
 
 void
 Init_extension(void)
@@ -2347,6 +2377,7 @@ Init_extension(void)
   cHistogram = rb_const_get_at(mEnumerableStatistics, rb_intern("Histogram"));
 
   rb_define_method(rb_cArray, "histogram", ary_histogram, -1);
+  rb_define_method(rb_cArray, "dual_histograms", ary_dual_histograms, -1);
 
   idPLUS = '+';
   idMINUS = '-';
@@ -2365,6 +2396,7 @@ Init_extension(void)
   id_sum = rb_intern("sum");
   id_population = rb_intern("population");
   id_closed = rb_intern("closed");
+  id_compare = rb_intern("compare");
   id_edge = rb_intern("edge");
 
   sym_left = ID2SYM(rb_intern("left"));

--- a/ext/enumerable/statistics/extension/statistics.c
+++ b/ext/enumerable/statistics/extension/statistics.c
@@ -2330,13 +2330,23 @@ ary_dual_histograms(int argc, VALUE *argv, VALUE ary)
 {
   VALUE arg0, opts;
   int left_p;
+
+  VALUE ary_edge, compare_ary_edge;
+  VALUE ary_nbins, compare_ary_nbins;
   long nbins, nweights, i;
-  VALUE compare;
+  VALUE compare_ary;
 
   rb_scan_args(argc, argv, "01:", &arg0, &opts);
-  compare = opt_compare_array(opts);
 
-  return compare;
+  left_p = opt_closed_left_p(opts);
+  compare_ary = opt_compare_array(opts);
+  ary_nbins = sturges(RARRAY_LEN(ary));
+  ary_edge = ary_histogram_calculate_edge(ary, ary_nbins, left_p);
+
+  /* compare_ary_nbins = sturges(RARRAY_LEN(ary)); */
+  /* compare_edge = ary_histogram_calculate_edge(compare_ary, compare_ary_nbins, left_p); */
+
+  return ary_edge;
 }
 
 

--- a/ext/enumerable/statistics/extension/statistics.c
+++ b/ext/enumerable/statistics/extension/statistics.c
@@ -2352,14 +2352,23 @@ ary_dual_histograms(int argc, VALUE *argv, VALUE ary)
 
   ary_diff = rb_funcall(rb_ary_entry(ary_edge, 1), idMINUS, 1, rb_ary_entry(ary_edge, 0));
   compare_ary_diff = rb_funcall(rb_ary_entry(compare_ary_edge, 1), idMINUS, 1, rb_ary_entry(compare_ary_edge, 0));
-  /* average_diff = rb_funcall(rb_funcall(ary_diff, idPLUS, 1, compare_ary_diff), rb_intern("/"), 1, rb_intern("2")); */
   average_diff = rb_funcall(rb_funcall(ary_diff, idPLUS, 1, compare_ary_diff), idDIV, 1, DBL2NUM(2.0));
 
   edges_max = rb_funcall(all_edges, rb_intern("max"), 0);
   edges_min = rb_funcall(all_edges, rb_intern("min"), 0);
-  rb_p(edges_min);
+  rb_p(edges_max);
 
-  rb_p(average_diff);
+  VALUE edges, last_edge;
+  last_edge = edges_min;
+
+  edges = rb_ary_new();
+
+  rb_ary_push(edges, last_edge);
+
+  while (RTEST(rb_funcall(last_edge, rb_intern("<"), 1, edges_max))) {
+    last_edge = rb_funcall(last_edge, idPLUS, 1, average_diff);
+    rb_ary_push(edges, last_edge);
+  }
 
   return compare_ary_edge;
 }

--- a/ext/enumerable/statistics/extension/statistics.c
+++ b/ext/enumerable/statistics/extension/statistics.c
@@ -30,8 +30,8 @@ static inline int
 enum_stat_integer_type_p(VALUE obj)
 {
     return (FIXNUM_P(obj) ||
-	    (!SPECIAL_CONST_P(obj) &&
-	     BUILTIN_TYPE(obj) == RUBY_T_BIGNUM));
+      (!SPECIAL_CONST_P(obj) &&
+       BUILTIN_TYPE(obj) == RUBY_T_BIGNUM));
 }
 #endif
 

--- a/spec/histogram/array_spec.rb
+++ b/spec/histogram/array_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe Array, '#histogram' do
 
   subject(:histogram) { ary.histogram(*args, **kwargs) }
 
+  context 'dualing_histogram' do
+    specify do
+
+      a = [1,1,1, 5, 5, 5, 5, 10, 10, 10]
+      b = [7, 7, 7, 12, 12, 12, 12, 20, 20, 20]
+      expect(a.histogram.edge.first).to_not eq(b.histogram.edge.first)
+      expect(a.histogram.edge.last).to_not eq(b.histogram.edge.last)
+
+      expect(a.dual_histograms(compare: b).edge.first).to eq(b.dual_histograms(compare: a).edge.first)
+      expect(a.dual_histograms(compare: b).edge.last).to eq(b.dual_histograms(compare: a).edge.last)
+    end
+  end
+
+
   with_array [] do
     context 'default' do
       specify do


### PR DESCRIPTION
Sorry for the messy PR, this isn't intended to be merged as is, but I wanted to instead make a proof of concept, explain my problem, and then start a dialog about how we can address that problem.

## Problem

I want to use histograms to how two different distributions compare to one another https://github.com/schneems/derailed_benchmarks/pull/169 however, if I generate a histogram for each, the edges aren't aligned so it's impossible to tell at a glance which distribution is "better".

## This Solution Implementation

I had the idea that we could align the edges of the two different distributions so that they can be easily graphed and compared. That's what this PR does. It generates an edge list for two different distributions, then it turns them into one edge list. To do this I averaged the bin size for each edge list and then I built another edge list going from the smallest edge value to the largest edge value using the averaged bin size.

## Unknowns

- C-extension clarity and quality. I don't spend a lot of time in c-extensions so I'm guessing some of this could be cleaned up dramatically.
- Interface (return values): Maybe instead of returning a single histogram, we want to return two histograms in an array or create a new histogram structure.
- Interface modularity: Does it make the most sense to have this special purpose method? Alternatively, we could maybe allow the `histogram` method to take an `edges:` argument, and expose a way to generate edges instead.

## Your feedback

I want to thank you a ton for creating an maintaining this library. I would like your feedback on this PR. Please let me know if anything is not clear or if you have any questions.