### PR TITLE
Fix Ruby find_min implementation

### DIFF
--- a/lib/enumerable_statistics/array_ext.rb
+++ b/lib/enumerable_statistics/array_ext.rb
@@ -22,7 +22,7 @@ module EnumerableStatistics
 
       imin, i = 0, 1
       while i < n
-        imin = i if self[i] < self[imax]
+        imin = i if self[i] < self[imin]
         i += 1
       end
       [self[imin], imin]


### PR DESCRIPTION
Fix the pure Ruby implementation of `find_min`.
Since this method is overridden by a method in the C extension, there is no actual harm.

```rb
require_relative "lib/enumerable_statistics/array_ext.rb"
p [3, 1, 2].find_min
```

Before

```console
/home/kojix2/Ruby/enumerable-statistics/lib/enumerable_statistics/array_ext.rb:25:in 'EnumerableStatistics::ArrayExtension#find_min': undefined local variable or method 'imax' for an instance of Array (NameError)

        imin = i if self[i] < self[imax]
                                   ^^^^
Did you mean?  max
        from (irb):2:in '<main>'
        from /home/kojix2/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/irb-1.17.0/exe/irb:9:in '<top (required)>'
        from /home/kojix2/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/rubygems.rb:303:in 'Kernel#load'
        from /home/kojix2/.local/share/mise/installs/ruby/4.0.1/lib/ruby/4.0.0/rubygems.rb:303:in 'Gem.activate_and_load_bin_path'
        from /home/kojix2/.local/share/mise/installs/ruby/4.0.1/bin/irb:25:in '<main>'
```

After

```console
=> [1, 1]
```